### PR TITLE
chore: move `process` tasks from t-linux-large to t-linux-docker workers

### DIFF
--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -21,8 +21,8 @@ workers:
       implementation: docker-worker
       os: linux
       worker-type: '{alias}-gcp'
-    t-linux-large:
+    t-linux:
       provisioner: '{trust-domain}-t'
       implementation: docker-worker
       os: linux
-      worker-type: '{alias}-gcp'
+      worker-type: '{alias}-docker'

--- a/taskcluster/kinds/process/kind.yml
+++ b/taskcluster/kinds/process/kind.yml
@@ -5,7 +5,7 @@ task-defaults:
   run-on-git-branches:
     - main
   # Ingest symbolication can take advantage of a lot of CPU (and disk space).
-  worker-type: t-linux-large
+  worker-type: t-linux
   worker:
     # Because all tasks rely on the ingester tasks right now, we just use the
     # same image for everything.


### PR DESCRIPTION
Part of https://bugzilla.mozilla.org/show_bug.cgi?id=1922504